### PR TITLE
feat: authorization

### DIFF
--- a/src/app/admin/manage-products/manage-products.service.ts
+++ b/src/app/admin/manage-products/manage-products.service.ts
@@ -31,8 +31,13 @@ export class ManageProductsService extends ApiService {
 
   private getPreSignedUrl(fileName: string): Observable<string> {
     const url = this.getUrl('import', 'import');
+    const authorizationToken =
+      localStorage.getItem('authorization_token') || '';
 
     return this.http.get<string>(url, {
+      headers: {
+        authorization: `Basic ${btoa(authorizationToken)}`,
+      },
       params: {
         name: fileName,
       },

--- a/src/app/core/interceptors/error-print.interceptor.ts
+++ b/src/app/core/interceptors/error-print.interceptor.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import {
+  HttpErrorResponse,
   HttpEvent,
   HttpHandler,
   HttpInterceptor,
@@ -19,11 +20,24 @@ export class ErrorPrintInterceptor implements HttpInterceptor {
   ): Observable<HttpEvent<unknown>> {
     return next.handle(request).pipe(
       tap({
-        error: () => {
+        error: (error: unknown) => {
           const url = new URL(request.url);
+          let message;
+
+          switch ((error as HttpErrorResponse).status.toString()) {
+            case '401':
+              message = `Authorization header is not provided.`;
+              break;
+            case '403':
+              message = `Access is denied.`;
+              break;
+            default:
+              message = 'Check the console for the details.';
+              break;
+          }
 
           this.notificationService.showError(
-            `Request to "${url.pathname}" failed. Check the console for the details`,
+            `Request to "${url.pathname}" failed. ${message}`,
             0
           );
         },


### PR DESCRIPTION
Main:

1 - authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
3 - Import Service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
5 - Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser [localStorage](https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage)

Additional tasks:
+1 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file.

Front-End application:
https://d2i4a65sjgrzhn.cloudfront.net/
Import API:
https://1cm3igs7r1.execute-api.eu-west-1.amazonaws.com/dev/import

Back-end PR link:
https://github.com/PavelKuzniatsou/shop-angular-cloudfront-backend/pull/5